### PR TITLE
add sourcepos argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Description: Casts (R)Markdown files to XML and back to allow their editing via 
 License: GPL-3
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 6.1.0.9000
+RoxygenNote: 7.1.0
 Imports: 
     magrittr,
     commonmark (>= 1.6),

--- a/R/to_xml.R
+++ b/R/to_xml.R
@@ -4,6 +4,9 @@
 #'
 #' @param path Path to the file.
 #' @param encoding Encoding to be used by readLines.
+#' @param sourcepos passed to [commonmark::markdown_xml()]. If `TRUE`, the
+#'   source position of the file will be included as a "sourcepos" attribute.
+#'   Defaults to `FALSE`.
 #'
 #' @return A list containing the YAML of the file (yaml)
 #' and its body (body) as XML.
@@ -16,7 +19,7 @@
 #' path2 <- system.file("extdata", "example2.Rmd", package = "tinkr")
 #' post_list2 <- to_xml(path2)
 #' post_list2
-to_xml <- function(path, encoding = "UTF-8"){
+to_xml <- function(path, encoding = "UTF-8", sourcepos = FALSE){
   content <- readLines(path, encoding = encoding)
 
   splitted_content <- split_yaml_body(content)
@@ -25,7 +28,7 @@ to_xml <- function(path, encoding = "UTF-8"){
 
   splitted_content$body %>%
     clean_content() %>%
-    commonmark::markdown_xml(extensions = TRUE) %>%
+    commonmark::markdown_xml(extensions = TRUE, sourcepos = sourcepos) %>%
     xml2::read_xml(encoding = encoding) -> body
 
   if(stringr::str_detect(fs::path_ext(path), "[Rr]")){

--- a/man/to_md.Rd
+++ b/man/to_md.Rd
@@ -4,8 +4,11 @@
 \alias{to_md}
 \title{Write YAML and XML back to disk as (R)Markdown}
 \usage{
-to_md(yaml_xml_list, path, stylesheet_path = system.file("extdata",
-  "xml2md_gfm.xsl", package = "tinkr"))
+to_md(
+  yaml_xml_list,
+  path,
+  stylesheet_path = system.file("extdata", "xml2md_gfm.xsl", package = "tinkr")
+)
 }
 \arguments{
 \item{yaml_xml_list}{result from a call to \code{to_xml} and editing.}

--- a/man/to_xml.Rd
+++ b/man/to_xml.Rd
@@ -4,12 +4,16 @@
 \alias{to_xml}
 \title{Transform file to XML}
 \usage{
-to_xml(path, encoding = "UTF-8")
+to_xml(path, encoding = "UTF-8", sourcepos = FALSE)
 }
 \arguments{
 \item{path}{Path to the file.}
 
 \item{encoding}{Encoding to be used by readLines.}
+
+\item{sourcepos}{passed to [commonmark::markdown_xml()]. If `TRUE`, the
+source position of the file will be included as a "sourcepos" attribute.
+Defaults to `FALSE`.}
 }
 \value{
 A list containing the YAML of the file (yaml)

--- a/tests/testthat/test-to_xml.R
+++ b/tests/testthat/test-to_xml.R
@@ -23,3 +23,13 @@ test_that("to_xml works for Rmd", {
   expect_equal(length(blocks), 4)
 
 })
+
+test_that("to_xml works with sourcepos", {
+  path <- system.file("extdata", "example1.md", package = "tinkr")
+  post_list <- to_xml(path, sourcepos = TRUE)
+  expect_equal(names(post_list)[1], "yaml")
+  expect_equal(names(post_list)[2], "body")
+  expect_is(post_list[[2]], "xml_document")
+  expect_true(xml2::xml_has_attr(post_list[[2]], "sourcepos"))
+  expect_match(xml2::xml_attr(post_list[[2]], "sourcepos"), "^1:1-\\d+?:\\d+$")
+})


### PR DESCRIPTION
<!-- IF THIS INVOLVES AUTHENTICATION: DO NOT SHARE YOUR USERNAME/PASSWORD, OR API KEYS/TOKENS IN THIS ISSUE - MOST LIKELY THE MAINTAINER WILL HAVE THEIR OWN EQUIVALENT KEY -->

<!-- If you've updated a file in the man-roxygen directory, make sure to update the man/ files by running devtools::document() or similar as .Rd files should be affected by your change -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I've added  a `sourcepos` argument to `to_xml()`; this allows the source position to be added as an attribute to the XML. It defaults to FALSE. 

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

``` r
library("tinkr")
path <- system.file("extdata", "example1.md", package = "tinkr")
post_list <- to_xml(path, sourcepos = TRUE)
xml2::xml_attr(post_list[[2]], "sourcepos")
#> [1] "1:1-446:63"
```

<sup>Created on 2020-05-12 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
