### PR TITLE
ensure Rmd chunks retain sourcepos attribute

### DIFF
--- a/R/to_xml.R
+++ b/R/to_xml.R
@@ -57,7 +57,12 @@ transform_block <- function(code_block){
   info <- transform_params(info)
 
   xml2::xml_set_attr(code_block, "info", NULL)
-  xml2::xml_set_attrs(code_block, info)
+  # preserve the original non-info attributes (e.g. sourcepos)
+  attrs <- xml2::xml_attrs(code_block)
+  # the space parameter seems to be persistant, so it's not needed
+  attrs <- attrs[names(attrs) != "space"]
+  # set the attributes for both info and attrs
+  xml2::xml_set_attrs(code_block, c(info, attrs))
   code_block
 }
 

--- a/tests/testthat/test-to_xml.R
+++ b/tests/testthat/test-to_xml.R
@@ -43,10 +43,12 @@ test_that("to_xml works with sourcepos for Rmd", {
   expect_true(xml2::xml_has_attr(post_list[[2]], "sourcepos"))
   expect_match(xml2::xml_attr(post_list[[2]], "sourcepos"), "^1:1-\\d+?:\\d+$")
   # code blocks retain their attributes
-  expect_true(
-    xml2::xml_has_attr(
-      xml2::xml_find_first(post_list[[2]], ".//d1:code_block"), 
-      "sourcepos"
-    )
-  )
+  first_block <- xml2::xml_find_first(post_list[[2]], ".//d1:code_block")
+
+  expect_match(xml2::xml_attr(first_block, "space"), "preserve")
+  expect_match(xml2::xml_attr(first_block, "sourcepos"), "^\\d+?:\\d+?-\\d+?:\\d+$")
+  expect_match(xml2::xml_attr(first_block, "language"), "r")
+  expect_match(xml2::xml_attr(first_block, "name"), "setup")
+  expect_match(xml2::xml_attr(first_block, "include"), "FALSE")
+  expect_match(xml2::xml_attr(first_block, "eval"), "TRUE")
 })

--- a/tests/testthat/test-to_xml.R
+++ b/tests/testthat/test-to_xml.R
@@ -33,3 +33,20 @@ test_that("to_xml works with sourcepos", {
   expect_true(xml2::xml_has_attr(post_list[[2]], "sourcepos"))
   expect_match(xml2::xml_attr(post_list[[2]], "sourcepos"), "^1:1-\\d+?:\\d+$")
 })
+
+test_that("to_xml works with sourcepos for Rmd", {
+  path <- system.file("extdata", "example2.Rmd", package = "tinkr")
+  post_list <- to_xml(path, sourcepos = TRUE)
+  expect_equal(names(post_list)[1], "yaml")
+  expect_equal(names(post_list)[2], "body")
+  expect_is(post_list[[2]], "xml_document")
+  expect_true(xml2::xml_has_attr(post_list[[2]], "sourcepos"))
+  expect_match(xml2::xml_attr(post_list[[2]], "sourcepos"), "^1:1-\\d+?:\\d+$")
+  # code blocks retain their attributes
+  expect_true(
+    xml2::xml_has_attr(
+      xml2::xml_find_first(post_list[[2]], ".//d1:code_block"), 
+      "sourcepos"
+    )
+  )
+})


### PR DESCRIPTION
I noticed that the `sourcepos` attribute was being stripped when the chunk info was being added. It seems that xml2 will strip attributes when new attributes are added. I've fixed it in this PR

``` r
library(magrittr)
path <- system.file("extdata", "example2.Rmd", package = "tinkr")
tinkr::to_xml(path, sourcepos = TRUE)$body %>%
  xml2::xml_find_first(".//d1:code_block") %>%
  xml2::xml_attrs()
#>  sourcepos      space   language       name    include       eval 
#>  "2:1-4:3" "preserve"        "r"    "setup"    "FALSE"     "TRUE"
```

<sup>Created on 2020-05-15 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>