### PR TITLE
add conditional to setting attributes for copy_xml

### DIFF
--- a/R/to_md.R
+++ b/R/to_md.R
@@ -64,7 +64,10 @@ copy_xml <- function(xml) {
   new_attrs <- unique(unlist(lapply(xml2::xml_attrs(new_text), names)))
 
   dff <- setdiff(new_attrs, old_attrs)
-  xml2::xml_set_attr(new_text, dff, NULL)
+
+  if (length(dff) > 0) {
+    xml2::xml_set_attr(new_text, dff, NULL)
+  }
 
   new
 }


### PR DESCRIPTION
I've found there are times where the namespace issue doesn't exist and
the attributes are exactly the same. This is coming from trying to
convert nested block quotes to code blocks, which involves this exact
process, so there might be something to that.

**I swear, one day I will actually submit a PR that works!!!**